### PR TITLE
hotfix/2.1.1  - handled decoding better and bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('requirements.txt', 'r') as fh:
 
 setup(
     name="tap-sftp",
-    version="2.1.0",
+    version="2.1.1",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -1,9 +1,10 @@
 import codecs
 import csv
+import io
 import os
 
-from tap_sftp.singer_encodings import compression
 from tap_sftp import decrypt
+from tap_sftp.singer_encodings import compression
 
 SDC_EXTRA_COLUMN = "_sdc_extra"
 
@@ -22,11 +23,9 @@ def get_row_iterator(iterable, options=None):
     which can be used to yield CSV rows."""
     options = options or {}
 
-    file_stream = codecs.iterdecode(iterable, encoding=options.get('encoding', 'utf-8'))
-
     # Replace any NULL bytes in the line given to the DictReader
     reader = csv.DictReader(
-        (line.replace('\0', '') for line in file_stream),
+        io.TextIOWrapper(iterable, encoding=options.get('encoding', 'utf-8')),
         fieldnames=None,
         restkey=SDC_EXTRA_COLUMN,
         delimiter=options.get('delimiter', ',')

--- a/tap_sftp/singer_encodings/json_schema.py
+++ b/tap_sftp/singer_encodings/json_schema.py
@@ -39,7 +39,8 @@ def sample_file(conn, table_spec, f, sample_rate, max_records, config):
     # Add file_name to opts and flag infer_compression to support gzipped files
     opts = {'key_properties': table_spec['key_properties'],
             'delimiter': table_spec['delimiter'],
-            'file_name': f['filepath']}
+            'file_name': f['filepath'],
+            'encoding': table_spec.get('encoding', 'utf-8')}
 
     readers = csv_handler.get_row_iterators(file_handle, options=opts, infer_compression=True)
 


### PR DESCRIPTION
- TextIOWrapper instead of codecs.
- codecs was being annoying with newline characters where TextIOWrapper manages it for us. We would need to handle newline characters either manually or at time of opening the file which is not ideal in either case.
- also I noticed that json_schema which is used for discovery was not accepting encoding parameters